### PR TITLE
Authenticate client certificateCN with client hostname (DB-113)

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -996,7 +996,7 @@ namespace EventStore.Core {
 			if (!options.Application.Insecure) {
 				//transport-level authentication providers
 				httpAuthenticationProviders.Add(
-					new ClientCertificateAuthenticationProvider(options.Certificate.CertificateReservedNodeCommonName));
+					new ClientCertificateAuthenticationProvider(options.Certificate.CertificateReservedNodeCommonName, options.Cluster.GossipSeed));
 
 				if (options.Interface.EnableTrustedAuth)
 					httpAuthenticationProviders.Add(new TrustedHttpAuthenticationProvider());


### PR DESCRIPTION
Added: Add check to verify the certificate CN matches with the client host name instead of using the reserved certificate common name.

Fixes https://linear.app/eventstore/issue/DB-113/reserved-common-name-for-gossip-seed
