### PR TITLE
Base Readiness From VNode State [DB-284]

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1535,8 +1535,7 @@ namespace EventStore.Core {
 				telemetryConfiguration,
 				trackers,
 				options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null);
-			_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
-			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);
+			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(_startup);
 			var certificateExpiryMonitor = new CertificateExpiryMonitor(_mainQueue, _certificateSelector, Log);
 			_mainBus.Subscribe<SystemMessage.SystemStart>(certificateExpiryMonitor);
 			_mainBus.Subscribe<MonitoringMessage.CheckCertificateExpiry>(certificateExpiryMonitor);


### PR DESCRIPTION
Nodes are not ready to handle outside traffic unless they are in the leader, follower, or readonly replica states.
