### PR TITLE
Improve the error message when reading $all stream from an invalid position

### DIFF
--- a/src/EventStore.Core/Data/FilteredReadAllResult.cs
+++ b/src/EventStore.Core/Data/FilteredReadAllResult.cs
@@ -7,5 +7,6 @@ namespace EventStore.Core.Data
         Error = 2,
         AccessDenied = 3,
         Expired = 4,
+        InvalidPosition = 5,
     }
 }

--- a/src/EventStore.Core/Data/ReadAllResult.cs
+++ b/src/EventStore.Core/Data/ReadAllResult.cs
@@ -5,5 +5,6 @@ namespace EventStore.Core.Data {
 		Error = 2,
 		AccessDenied = 3,
 		Expired = 4,
+		InvalidPosition = 5,
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
@@ -123,6 +123,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						case ReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(RpcExceptions.AccessDenied());
 							return;
+						case ReadAllResult.InvalidPosition:
+							_channel.Writer.TryComplete(RpcExceptions.InvalidPositionException());
+							return;
 						default:
 							_channel.Writer.TryComplete(RpcExceptions.UnknownError(completed.Result));
 							return;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
@@ -141,6 +141,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						case FilteredReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(RpcExceptions.AccessDenied());
 							return;
+						case FilteredReadAllResult.InvalidPosition:
+							_channel.Writer.TryComplete(RpcExceptions.InvalidPositionException());
+							return;
 						default:
 							_channel.Writer.TryComplete(RpcExceptions.UnknownError(completed.Result));
 							return;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -119,6 +119,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						case ReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(RpcExceptions.AccessDenied());
 							return;
+						case ReadAllResult.InvalidPosition:
+							_channel.Writer.TryComplete(RpcExceptions.InvalidPositionException());
+							return;
 						default:
 							_channel.Writer.TryComplete(RpcExceptions.UnknownError(completed.Result));
 							return;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -143,6 +143,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						case FilteredReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(RpcExceptions.AccessDenied());
 							return;
+						case FilteredReadAllResult.InvalidPosition:
+							_channel.Writer.TryComplete(RpcExceptions.InvalidPositionException());
+							return;
 						default:
 							_channel.Writer.TryComplete(RpcExceptions.UnknownError(completed.Result));
 							return;

--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -232,5 +232,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 		public static RpcException InvalidCombination<T>(T combination) where T : ITuple
 			=> new(new Status(StatusCode.InvalidArgument, $"The combination of {combination} is invalid."));
+		
+		public static RpcException InvalidPositionException() =>
+			new(new Status(StatusCode.InvalidArgument, $"Trying to read from an invalid position."));
 	}
 }


### PR DESCRIPTION
Fixed : Improves the error message on the client side when the client tries to read from an invalid position. When this happened, the error message on the client side was unclear stating "Unexpected : ReadAllResult.Error". This PR improves the error message when the above issue is encountered.