### PR TITLE
[KDB-720] Add GHA Step Summaries to container CI

### DIFF
--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -72,12 +72,19 @@ jobs:
         build-args: |
           CONTAINER_RUNTIME=${{ inputs.container-runtime }}
           RUNTIME=${{ steps.variables.outputs.runtime }}
+    # pass env vars so that GitHubActionsTestLogger can populate GitHub job summary 
     - name: Run Tests
-      run: |
-          docker run \
-          --volume $(pwd)/test-results:/build/test-results \
-          --rm \
-          eventstore-test
+      run: >
+        docker run
+        --volume $(pwd)/test-results:/build/test-results
+        --volume ${{ github.step_summary }}:/build/step-summary
+        --rm
+        --env GITHUB_STEP_SUMMARY=/build/step-summary
+        --env GITHUB_SERVER_URL=${{ github.server_url }}
+        --env GITHUB_REPOSITORY=${{ github.repository }}
+        --env GITHUB_WORKSPACE=${{ github.workspace }}
+        --env GITHUB_SHA=${{ github.sha }}
+        eventstore-test
     - name: Publish Test Results (HTML)
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
e.g. https://github.com/kurrent-io/EventStore/actions/runs/14101249514?pr=4946

This PR plumbs through the necessary environment variables and bind mounts the step summary file to make it available to the container.

Useful discussion: https://github.com/Tyrrrz/GitHubActionsTestLogger/issues/6


