### PR TITLE
[KDB-678] Rename unix socket from `eventstore.sock` to `kurrent.sock`

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4726,12 +4726,12 @@
           }
         ],
         "package": {
-          "name": "event_store.client.redaction"
+          "name": "kurrent.client.redaction"
         },
         "options": [
           {
             "name": "java_package",
-            "value": "com.eventstore.dbclient.proto.redaction"
+            "value": "com.kurrent.dbclient.proto.redaction"
           }
         ]
       }

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/ServerFeaturesTests/ServerFeaturesTest.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/ServerFeaturesTests/ServerFeaturesTest.cs
@@ -44,7 +44,7 @@ public class ServerFeaturesTest {
 			_expectedEndPoints.AddRange(GetEndPoints(Client.Users.Users.Descriptor));
 			_expectedEndPoints.AddRange(GetEndPoints(Client.Gossip.Gossip.Descriptor));
 			_expectedEndPoints.AddRange(GetEndPoints(Client.Monitoring.Monitoring.Descriptor));
-			_expectedEndPoints.AddRange(GetEndPoints(Client.Redaction.Redaction.Descriptor));
+			_expectedEndPoints.AddRange(GetEndPoints(Kurrent.Client.Redaction.Redaction.Descriptor));
 			_expectedEndPoints.AddRange(GetEndPoints(ServerFeatures.Descriptor));
 
 			var versionParts = EventStore.Common.Utils.VersionInfo.Version.Split('.');

--- a/src/EventStore.Core/Services/Transport/Grpc/Redaction.GetEventPositions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Redaction.GetEventPositions.cs
@@ -2,7 +2,7 @@
 // Kurrent, Inc licenses this file to you under the Kurrent License v1 (see LICENSE.md).
 
 using System.Threading.Tasks;
-using EventStore.Client.Redaction;
+using Kurrent.Client.Redaction;
 using EventStore.Core.Data.Redaction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
@@ -45,9 +45,9 @@ internal partial class Redaction {
 			var response = new GetEventPositionResp();
 			foreach (var eventPosition in eventPositions) {
 				var pos = Position.FromInt64(eventPosition.LogPosition, eventPosition.LogPosition);
-				response.EventPositions.Add(new EventStore.Client.Redaction.EventPosition {
+				response.EventPositions.Add(new Kurrent.Client.Redaction.EventPosition {
 					LogPosition = pos.PreparePosition,
-					ChunkInfo = new EventStore.Client.Redaction.ChunkInfo {
+					ChunkInfo = new Kurrent.Client.Redaction.ChunkInfo {
 						FileName = eventPosition.ChunkInfo.FileName,
 						Version = eventPosition.ChunkInfo.Version,
 						IsComplete = eventPosition.ChunkInfo.IsComplete,

--- a/src/EventStore.Core/Services/Transport/Grpc/Redaction.SwitchChunks.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Redaction.SwitchChunks.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using EventStore.Client.Redaction;
+using Kurrent.Client.Redaction;
 using EventStore.Core.Data.Redaction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;

--- a/src/EventStore.Core/Services/Transport/Grpc/Redaction.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Redaction.cs
@@ -6,7 +6,7 @@ using EventStore.Plugins.Authorization;
 
 namespace EventStore.Core.Services.Transport.Grpc;
 
-internal partial class Redaction : EventStore.Client.Redaction.Redaction.RedactionBase {
+internal partial class Redaction : Kurrent.Client.Redaction.Redaction.RedactionBase {
 	private readonly IPublisher _bus;
 	private readonly IAuthorizationProvider _authorizationProvider;
 

--- a/src/Protos/Grpc/redaction.proto
+++ b/src/Protos/Grpc/redaction.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package event_store.client.redaction;
-option java_package = "com.eventstore.dbclient.proto.redaction";
+package kurrent.client.redaction;
+option java_package = "com.kurrent.dbclient.proto.redaction";
 
 import "shared.proto";
 


### PR DESCRIPTION
Check for and clean up `eventstore.sock` in addition to `kurrent.sock` at startup.
Update the namespaces for the redaction proto.

I've labeled this as a breaking change because it won't work with older versions of the redactor tool, but there is no breaking change between server versions.

This will only be compatible with the `KurrentDB.Redactor` tool