### PR TITLE
Fixed typo in docs for EVENTSTORE_NODE_PRIORITY

### DIFF
--- a/docs/server/configuration/cluster.md
+++ b/docs/server/configuration/cluster.md
@@ -222,7 +222,7 @@ You can control which clones the cluster promotes with the `NodePriority` settin
 |:---------------------|:--------------------------|
 | Command line         | `--node-priority`         |
 | YAML                 | `NodePriority`            |
-| Environment variable | `EVENTSTORE_NODE_PRORITY` |
+| Environment variable | `EVENTSTORE_NODE_PRIORITY` |
 
 **Default**: `0`.
 


### PR DESCRIPTION
Copies https://github.com/kurrent-io/EventStore/pull/4643 to v24.10