### PR TITLE
[KDB-744] Fix: Filtered $all subscriptions checkpoint behaviour change

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -606,6 +606,11 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 			list.Add(BuildEvent(record.Value, message.ResolveLinkTos, record.Key.CommitPosition));
 		}
 
+		if (records.IsEmpty()) {
+			var lastPos = _all.Keys[^1];
+			next = new TFPos(lastPos.CommitPosition, lastPos.PreparePosition + 1);
+		}
+
 		var events = list.ToArray();
 		message.Envelope.ReplyWith(
 			new ClientMessage.FilteredReadAllEventsForwardCompleted(

--- a/src/EventStore.Core/Data/TFPos.cs
+++ b/src/EventStore.Core/Data/TFPos.cs
@@ -9,6 +9,7 @@ namespace EventStore.Core.Data;
 public struct TFPos : IEquatable<TFPos>, IComparable<TFPos> {
 	public static readonly TFPos Invalid = new TFPos(-1, -1);
 	public static readonly TFPos HeadOfTf = new TFPos(-1, -1);
+	public static readonly TFPos FirstRecordOfTf = new TFPos(0, 0);
 
 	public readonly long CommitPosition;
 	public readonly long PreparePosition;

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -296,17 +296,27 @@ ReadLoop:
 								checkpoint = eventPosition;
 							}
 
+							if (checkpoint < completed.CurrentPos && completed.CurrentPos < completed.NextPos) {
+								// note: when completed.CurrentPos == completed.NextPos, we can't use completed.CurrentPos
+								// as checkpoint as we haven't yet processed the record at that position
+								checkpoint = completed.CurrentPos;
+							}
+
 							checkpointIntervalCounter += completed.ConsideredEventsCount;
 							Log.Verbose(
 								"Subscription {subscriptionId} to $all:{eventFilter} considered {consideredEventsCount} catch-up events (interval: {checkpointInterval}, counter: {checkpointIntervalCounter})",
 								_subscriptionId, _eventFilter, completed.ConsideredEventsCount, _checkpointInterval, checkpointIntervalCounter);
 
 							if (completed.IsEndOfStream) {
+								if (checkpoint < TFPos.FirstRecordOfTf && TFPos.FirstRecordOfTf < completed.NextPos) {
+									// we've reached the end of the log but didn't have any checkpoint updates.
+									// this can happen when we've read a single page from the transaction log.
+									// we set a trivial checkpoint to preserve the checkpoint interval semantics.
+									checkpoint = TFPos.FirstRecordOfTf;
+								}
+
 								// issue a checkpoint when going live to make sure that at least
 								// one checkpoint is issued within the checkpoint interval
-								if (checkpoint < completed.CurrentPos)
-									checkpoint = completed.CurrentPos;
-
 								await SendCheckpointToSubscription(checkpoint, ct);
 
 								catchupCompletionTcs.TrySetResult(checkpoint);
@@ -315,9 +325,6 @@ ReadLoop:
 
 							if (checkpointIntervalCounter >= _checkpointInterval) {
 								checkpointIntervalCounter %= _checkpointInterval;
-
-								if (checkpoint < completed.CurrentPos)
-									checkpoint = completed.CurrentPos;
 
 								Log.Verbose(
 									"Subscription {subscriptionId} to $all:{eventFilter} reached checkpoint at {position} during catch-up (interval: {checkpointInterval}, counter: {checkpointIntervalCounter})",

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.Services.Transport.Enumerators;
 
 public static partial class Enumerator {
 	private const int MaxLiveEventBufferCount = 32;
-	private const int ReadBatchSize = 32; // TODO  JPB make this configurable
+	public const int ReadBatchSize = 32; // TODO  JPB make this configurable
 
 	private static readonly BoundedChannelOptions BoundedChannelOptions =
 		new(MaxLiveEventBufferCount) {


### PR DESCRIPTION
Cherry-picks https://github.com/kurrent-io/EventStore/pull/4975 to v25.0

* Fix: When there's an empty page read, filtered $all subscriptions can send an incorrect checkpoint equal to the end position of the log

* Add test to ensure that events strictly advance the checkpoint and commit position in particular (when no explicit transactions)

---------